### PR TITLE
Relax xpath version to allow capybara >= 3

### DIFF
--- a/capybara_table.gemspec
+++ b/capybara_table.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency "capybara", ">= 2.0"
-  spec.add_dependency "xpath", "~> 2.1"
+  spec.add_dependency "xpath", ">= 2.1"
   spec.add_dependency "terminal-table"
 end

--- a/spec/capybara_table_spec.rb
+++ b/spec/capybara_table_spec.rb
@@ -59,7 +59,7 @@ describe CapybaraTable, type: :feature do
       matcher.matches?(node)
 
       expect(matcher.failure_message).to eq <<~MESSAGE.chomp
-        expected to find visible table_row {"First Name"=>"Moo"} within #<Capybara::Node::Simple tag="table" path="/html/body/table"> 2 times but there were no matches in the following tables:
+        expected to find table_row {"First Name"=>"Moo"} within #<Capybara::Node::Simple tag="table" path="/html/body/table"> 2 times but there were no matches in the following tables:
 
         +------------+-----------+-----+
         | First Name | Last Name | Age |


### PR DESCRIPTION
Seems like `capybara ~> 3.0` depends on `xpath ~> 3.0`