### PR TITLE
Update Changed Internal Capybara Class Name

### DIFF
--- a/capybara_table.gemspec
+++ b/capybara_table.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_dependency "capybara", ">= 2.0"
-  spec.add_dependency "xpath", "~> 2.1"
+  spec.add_dependency "xpath", ">= 2.1"
   spec.add_dependency "terminal-table"
 end

--- a/lib/capybara_table/rspec.rb
+++ b/lib/capybara_table/rspec.rb
@@ -10,7 +10,13 @@ module CapybaraTable
 
     matcher :have_table_row do |fields_and_options|
       fields, options = fields_and_options.partition { |k, v| k.is_a?(String) }.map(&:to_h)
-      selector = Capybara::RSpecMatchers::HaveSelector.new(:table_row, fields, options)
+
+      klass = begin
+        Capybara::RSpecMatchers::Matchers::HaveSelector
+      rescue NameError
+        Capybara::RSpecMatchers::HaveSelector
+      end
+      selector = klass.new(:table_row, fields, options)
 
       match do |node|
         selector.matches?(node)

--- a/spec/capybara_table_spec.rb
+++ b/spec/capybara_table_spec.rb
@@ -59,7 +59,7 @@ describe CapybaraTable, type: :feature do
       matcher.matches?(node)
 
       expect(matcher.failure_message).to eq <<~MESSAGE.chomp
-        expected to find visible table_row {"First Name"=>"Moo"} within #<Capybara::Node::Simple tag="table" path="/html/body/table"> 2 times but there were no matches in the following tables:
+        expected to find table_row {"First Name"=>"Moo"} within #<Capybara::Node::Simple tag="table" path="/html/body/table"> 2 times but there were no matches in the following tables:
 
         +------------+-----------+-----+
         | First Name | Last Name | Age |


### PR DESCRIPTION
See e3f5ffb for a bit more info. This PR is branched from @richardbrodie's commit in PR #6 as we cannot even get to 3.11+ of Capybara until that is applied.