### PR TITLE
Double splat kwargs to avoid warnings in ruby 2.7

### DIFF
--- a/lib/capybara_table/rspec.rb
+++ b/lib/capybara_table/rspec.rb
@@ -16,7 +16,7 @@ module CapybaraTable
       rescue NameError
         Capybara::RSpecMatchers::HaveSelector
       end
-      selector = klass.new(:table_row, fields, options)
+      selector = klass.new(:table_row, fields, **options)
 
       match do |node|
         selector.matches?(node)


### PR DESCRIPTION
`warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call` no more. 